### PR TITLE
fix(index): require avro in lowercase

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const camelize = require('./camelize');
-const convertToAvro = require('./convert/Avro');
+const convertToAvro = require('./convert/avro');
 const convertToGraphQL = require('./convert/GraphQL');
 const convertToOAS2 = require('./convertToOAS2');
 const createModelSchema = require('./createModelSchema');


### PR DESCRIPTION
This PR fixes casing issue for Avro converter.

Details:
Error: Cannot find module './convert/Avro'
    at Function.Module._resolveFilename (module.js:538:15)
    at Function.Module._load (module.js:468:25)
    at Module.require (module.js:587:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/t/sources/pim/product-service-api/specification/node_modules/@supermodel/lib/lib/index.js:3:21)
    at Module._compile (module.js:643:30)
    at Object.Module._extensions..js (module.js:654:10)
    at Module.load (module.js:556:32)
    at tryModuleLoad (module.js:499:12)
    at Function.Module._load (module.js:491:3)